### PR TITLE
Add option on slack bot to withdraw a created issue

### DIFF
--- a/src/service/jiraTicketTypes.js
+++ b/src/service/jiraTicketTypes.js
@@ -1,8 +1,8 @@
 class JiraType {
-    static ISSUE = new JiraType('Task', 3, 281, 31, 'Support request');
-    static BUG = new JiraType('Bug', 10900, 281, 31, 'Bug');
-    static SERVICE = new JiraType('Open ID Connect Service', 17701, 51, 61, 'OpenID Connect Service');
-    static ROLE = new JiraType('User Role', 17702, 51, 61, 'User Role');
+    static ISSUE = new JiraType('Task', 3, 281, 31, 181, 'Support request');
+    static BUG = new JiraType('Bug', 10900, 281, 31, 181, 'Bug');
+    static SERVICE = new JiraType('Open ID Connect Service', 17701, 51, 61, 31, 'OpenID Connect Service');
+    static ROLE = new JiraType('User Role', 17702, 51, 61, 31, 'User Role');
 
     static jiraRequestTypeMap = new Map([
         [JiraType.ISSUE.requestType, JiraType.ISSUE],
@@ -11,11 +11,12 @@ class JiraType {
         [JiraType.ROLE.requestType, JiraType.ROLE]
     ])
 
-    constructor(name, id, startTransitionId, endTransitionId, requestType) {
+    constructor(name, id, startTransitionId, endTransitionId, withdrawTransitionId, requestType) {
         this.name = name
         this.id = id
         this.startTransitionId = startTransitionId
         this.endTransitionId = endTransitionId
+        this.withdrawTransitionId = withdrawTransitionId
         this.requestType = requestType
     }
 

--- a/src/service/persistence.functional.test.js
+++ b/src/service/persistence.functional.test.js
@@ -48,10 +48,10 @@ describe('functional tests', () => {
     });
 
     test('issue is in progress', async () => {
-        await jira.startHelpRequest('SBOX-51')
+        await jira.transitionHelpRequest('SBOX-51')
     });
 
     test('issue is resolved', async () => {
-        await jira.resolveHelpRequest('SBOX-51')
+        await jira.transitionHelpRequest('SBOX-51')
     });
 })

--- a/src/service/persistence.js
+++ b/src/service/persistence.js
@@ -16,30 +16,17 @@ const jira = new JiraApi({
     strictSSL: true
 });
 
-async function resolveHelpRequest(jiraId, jiraDoneTransitionId) {
+async function transitionHelpRequest(jiraId, jiraTransitionId) {
     try {
         await jira.transitionIssue(jiraId, {
             transition: {
-                id: jiraDoneTransitionId
+                id: jiraTransitionId
             }
         })
     } catch (err) {
-        console.log("Error resolving help request in jira", err)
+        console.log("Error updating help request transition in jira", err)
     }
 }
-
-async function startHelpRequest(jiraId, jiraStartTransitionId) {
-    try {
-        await jira.transitionIssue(jiraId, {
-            transition: {
-                id: jiraStartTransitionId
-            }
-        })
-    } catch (err) {
-        console.log("Error starting help request in jira", err)
-    }
-}
-
 
 async function searchForUnassignedOpenIssues() {
     const jqlQuery = `project = ${jiraProject} AND type = "${JiraType.ISSUE.name}" AND status = Open and assignee is EMPTY AND labels not in ("Heritage") ORDER BY created ASC`;
@@ -222,8 +209,7 @@ function checkboxValue(value) {
     return 'N'
 }
 
-module.exports.resolveHelpRequest = resolveHelpRequest
-module.exports.startHelpRequest = startHelpRequest
+module.exports.transitionHelpRequest = transitionHelpRequest
 module.exports.assignHelpRequest = assignHelpRequest
 module.exports.createHelpRequest = createHelpRequest
 module.exports.updateHelpRequestDescription = updateHelpRequestDescription

--- a/src/util/blockHelper.js
+++ b/src/util/blockHelper.js
@@ -26,6 +26,27 @@ function updateActionsElement(blocks, actionIdRegex, value) {
     }
 }
 
+function addNewActionsElement(blocks, value) {
+    for (let i = 0; i < blocks.length; i++) {
+        if (blocks[i].type === 'actions') {
+            blocks[i].elements.push(value)
+        }
+    }
+}
+
+function removeActionsElement(blocks, actionIdRegex) {
+    for (let i = 0; i < blocks.length; i++) {
+        if (blocks[i].type === 'actions') {
+            const elements = blocks[i].elements
+            for (let j = 0; j < elements.length; j++) {
+                if (elements[j].action_id.match(actionIdRegex)) {
+                    blocks[i].elements.splice(j, 1);
+                }
+            }
+        }
+    }
+}
+
 function getContextElement(blocks, text) {
     for (let i = 0; i < blocks.length; i++) {
         const block = blocks[i]
@@ -61,6 +82,8 @@ function getSectionField(blocks, text) {
 module.exports = {
     getActionsElement,
     updateActionsElement,
+    addNewActionsElement,
+    removeActionsElement,
     getContextElement,
     getSectionField
 }

--- a/src/util/blockhelper.test.js
+++ b/src/util/blockhelper.test.js
@@ -1,7 +1,4 @@
-const {updateActionsElement} = require("./blockHelper");
-const {getSectionField} = require("./blockHelper");
-const {getContextElement} = require("./blockHelper");
-const {getActionsElement} = require("./blockHelper");
+const {getActionsElement, updateActionsElement, addNewActionsElement, removeActionsElement, getContextElement, getSectionField} = require("./blockHelper");
 
 
 describe('blockHelper', () => {
@@ -49,58 +46,79 @@ describe('blockHelper', () => {
         }
     ]
 
-    const originalElement = {
-        type: 'button',
-        value: 'action_2',
-        action_id: 'action_2'
-    }
+    describe('Actions element', () => {
+        const originalElement = {
+            type: 'button',
+            value: 'action_2',
+            action_id: 'action_2'
+        }
 
-    const updatedElement = {
+        const updatedElement = {
             type: 'button',
             value: 'action_3',
             action_id: 'action_3'
-    }
+        }
 
-    it('Should get action element', () => {
-        const element = getActionsElement(blocks, /action_2|action_3/)
-        expect(element.value).toBe('action_2')
+        it('Should get action element', () => {
+            const element = getActionsElement(blocks, /action_2|action_3/)
+            expect(element.value).toBe('action_2')
+        })
+
+        it('Should not get action element if element does not exist', () => {
+            const element = getActionsElement(blocks, /action_3|action_4/)
+            expect(element).toBeNull()
+        })
+
+        it('Should update action element', () => {
+            updateActionsElement(blocks, /action_2|action_3/, updatedElement)
+            expect(blocks[3].elements[1].value).toBe(updatedElement.value)
+
+            updateActionsElement(blocks, /action_2|action_3/, originalElement)
+            expect(blocks[3].elements[1].value).toBe(originalElement.value)
+        })
+
+        it('Should not update action element if element does not exist', () => {
+            updateActionsElement(blocks, /action_10/, updatedElement)
+            expect(blocks[3].elements[1].value).toBe(originalElement.value)
+        })
+
+        it('Should add and remove action element', () => {
+            const elementToAdd = {
+                type: 'button',
+                value: 'action_4',
+                action_id: 'action_4'
+            }
+            addNewActionsElement(blocks, elementToAdd)
+            let element = getActionsElement(blocks, /action_4/)
+            expect(element.value).toBe('action_4')
+
+            removeActionsElement(blocks, /action_4/)
+            element = getActionsElement(blocks, /action_4/)
+            expect(element).toBeNull()
+        })
     })
 
-    it('Should not get action element if element does not exist', () => {
-        const element = getActionsElement(blocks, /action_3|action_4/)
-        expect(element).toBeNull()
+    describe('Context element', () => {
+        it('Should get context element', () => {
+            const element = getContextElement(blocks, 'View on Jira')
+            expect(element.text).toBe(`${contextElementText}`)
+        })
+
+        it('Should not get context element if element does not exist', () => {
+            const element = getContextElement(blocks, 'Different text')
+            expect(element).toBeNull()
+        })
     })
 
-    it('Should update action element', () => {
-        updateActionsElement(blocks, /action_2|action_3/, updatedElement)
-        expect(blocks[3].elements[1].value).toBe(updatedElement.value)
+    describe('Section field', () => {
+        it('Should get section field', () => {
+            const field = getSectionField(blocks, 'field_2')
+            expect(field.text).toBe('field_2')
+        })
 
-        updateActionsElement(blocks, /action_2|action_3/, originalElement)
-        expect(blocks[3].elements[1].value).toBe(originalElement.value)
-    })
-
-    it('Should not update action element if element does not exist', () => {
-        updateActionsElement(blocks, /action_10/, updatedElement)
-        expect(blocks[3].elements[1].value).toBe(originalElement.value)
-    })
-
-    it('Should get context element', () => {
-        const element = getContextElement(blocks, 'View on Jira')
-        expect(element.text).toBe(`${contextElementText}`)
-    })
-
-    it('Should not get context element if element does not exist', () => {
-        const element = getContextElement(blocks, 'Different text')
-        expect(element).toBeNull()
-    })
-
-    it('Should get section field', () => {
-        const field = getSectionField(blocks, 'field_2')
-        expect(field.text).toBe('field_2')
-    })
-
-    it('Should not get section field if field does not exist', () => {
-        const field = getSectionField(blocks, 'field_3')
-        expect(field).toBeNull()
+        it('Should not get section field if field does not exist', () => {
+            const field = getSectionField(blocks, 'field_3')
+            expect(field).toBeNull()
+        })
     })
 })

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -59,29 +59,24 @@ const action = () => {
                 },
                 "action_id": "assign_help_request_to_user"
             },
-            {
-                "type": "button",
-                "text": {
-                    "type": "plain_text",
-                    "text": ":raising_hand: Take it",
-                    "emoji": true
-                },
-                "style": "primary",
-                "value": "assign_help_request_to_me",
-                "action_id": "assign_help_request_to_me"
-            },
-            {
-                "type": "button",
-                "text": {
-                    "type": "plain_text",
-                    "text": ":female-firefighter: Start",
-                    "emoji": true
-                },
-                "style": "primary",
-                "value": "start_help_request",
-                "action_id": "start_help_request"
-            }
+            button(":raising_hand: Take it", "assign_help_request_to_me"),
+            button(":female-firefighter: Start", "start_help_request"),
+            button(":broom: Withdraw", "withdraw_help_request")
         ]
+    }
+}
+
+const button = (text, action) => {
+    return {
+        "type": "button",
+        "text": {
+            "type": "plain_text",
+            "text": text,
+            "emoji": true
+        },
+        "style": "primary",
+        "value": action,
+        "action_id": action
     }
 }
 
@@ -99,6 +94,7 @@ module.exports = {
     title,
     jiraView,
     action,
+    button,
     textField
 }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-6742

### Change description ###

Add a new button on slack bot to withdraw a created issue.
1. After an issue has been withdrawn, the 'Withdraw' button will disappear and the text on the 'Start' button will be  updated to 'Re-open'.
2. If the withdrawn issue is re-open, the 'Withdraw' button will re-appear.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
