### PR TITLE
SIDM-8121 - Added user roles managed through access-config announcement

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -241,7 +241,26 @@ function createOIDCServiceAnnouncement() {
             }
         },
     ]
-};
+}
+
+function createNewRoleAnnouncement() {
+    return [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*UPDATE 6th December 2022*"
+            }
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "Role creation is now managed by the <https://github.com/hmcts/idam-access-config|idam-access-config> pipeline. Please refer to the <https://github.com/hmcts/idam-access-config/blob/master/README.md#roles-model|README> or have a look at how other teams have added their roles."
+            }
+        },
+    ]
+}
 
 function appHomeUnassignedIssues(openIssueBlocks) {
     return [
@@ -483,5 +502,6 @@ module.exports = {
     newRoleRequestRaised,
     openHelpRequestBlocks,
     createOIDCServiceAnnouncement,
+    createNewRoleAnnouncement,
     extractSlackLinkFromText
 }

--- a/src/service/helpRequestManager.js
+++ b/src/service/helpRequestManager.js
@@ -47,19 +47,6 @@ async function handleBugReport(client, user, helpRequest) {
     })
 }
 
-async function handleNewRoleRequest(client, user, helpRequest) {
-    const userEmail = await getUserEmail(client, user)
-    const jiraId = await createHelpRequest(helpRequest, userEmail, JiraType.ROLE.id)
-    console.log(`New user role request ${jiraId} created in Jira from ${reportChannel}`)
-
-    await postSlackMessages(client,
-        newRoleRequestRaised({
-            ...helpRequest,
-            jiraId
-        }),
-    )
-}
-
 async function getUserEmail(client, user) {
     return (await client.users.profile.get({
         user
@@ -104,5 +91,4 @@ async function postSlackMessages(client, requestInfoBlocks, requestDetailsBlocks
 module.exports = {
     handleSupportRequest,
     handleBugReport,
-    handleNewRoleRequest
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/SIDM-8121

### Change description ###

- Removed flow for raising user role requests through Slackbot
- Added announcement redirecting users to the access-config repo for role creation

<img width="457" alt="image" src="https://user-images.githubusercontent.com/32871802/205945730-852a973f-5119-4700-a6f3-57f5a31a4cde.png">

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
